### PR TITLE
Add config option to ignore certain methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ gem "lita-metrics"
   * `:command` - A boolean indicating whether the message was a command
   * `:handler` - The name of the handler invoked. Not available for invalid commands
   * `:method` - The name of the handler method invoked. Not available for invalid commands
+* `ignored_methods` - An array of methods that should be ignored. Useful for handler methods that "overhear" messages not necessarily directed at the bot. Default: `[]`
 
 ``` ruby
 Lita.configure do |config|
@@ -43,6 +44,7 @@ Lita.configure do |config|
   config.handlers.metrics.valid_command_metric = 'lita.messages.all'
   config.handlers.metrics.invalid_command_metric = 'lita.messages.failed'
   config.handlers.metrics.log_fields = [:user, :handler, :message]
+  config.handlers.metrics.ignored_methods = ['Jira#ambient']
 end
 ```
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'simplecov'
 require 'coveralls'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+SimpleCov.formatters = [
   SimpleCov::Formatter::HTMLFormatter,
   Coveralls::SimpleCov::Formatter
 ]


### PR DESCRIPTION
Handler methods like GoogleTranslate#interpret_monitor and Jira#ambient "overhear" messages and are recorded as commands. In order to avoid command metric inflation, the user can now specify handler methods to be ignored by lita-metrics.