### PR TITLE
relax dogstatsd-ruby version bounds

### DIFF
--- a/lib/lita/handlers/metrics.rb
+++ b/lib/lita/handlers/metrics.rb
@@ -96,7 +96,7 @@ module Lita
       end
 
       def same?(a, b)
-        a.to_s.downcase == b.to_s.downcase
+        a.to_s.casecmp(b.to_s) == 0
       end
     end
 

--- a/lita-metrics.gemspec
+++ b/lita-metrics.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'lita', '>= 4.6'
-  spec.add_runtime_dependency 'dogstatsd-ruby', '~> 1.5.0'
+  spec.add_runtime_dependency 'dogstatsd-ruby', '~> 1.6'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
When updating lita-money, I got the following error:

```
Bundler could not find compatible versions for gem "dogstatsd-ruby":
  In snapshot (Gemfile.lock):
    dogstatsd-ruby (= 1.5.0)

  In Gemfile:
    lita-metrics was resolved to 0.1.1, which depends on
      dogstatsd-ruby (~> 1.5.0)

    lita-money was resolved to 0.1.0, which depends on
      dogstatsd-ruby (~> 1.6)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

changes look harmless https://github.com/DataDog/dogstatsd-ruby/compare/v1.5.0...DataDog:v1.6.0